### PR TITLE
prevent crash while components are initializing

### DIFF
--- a/aframe-xylayout.js
+++ b/aframe-xylayout.js
@@ -23,7 +23,7 @@ AFRAME.registerComponent('xycontainer', {
         if (direction == "none") {
             return;
         }
-        let containerRect = this.el.components.xyrect;
+        let containerRect = this.el.components.xyrect.data? this.el.components.xyrect : {data: {height:-1, width:-1}}
         let children = /** @type {Iterable<AFRAME.AEntity>} */ (this.el.children);
         let isVertical = direction == "vertical" || direction == "column";
         let padding = data.padding;


### PR DESCRIPTION
First of all, thank you for working on this library.
Scenario: I was trying to create the `list.html`-example markup programmatically using javascript (`.appendChild(..)` e.g.)
And I got this error:

![image](https://user-images.githubusercontent.com/180068/190655300-8cf0e10e-dfdd-4feb-b5c4-71fcf5f7acab.png)

> with this fix it won't break during this first update (while other components are initializing I guess)